### PR TITLE
Make internal cd more in line with cmd.exe's cd

### DIFF
--- a/PyCmd.py
+++ b/PyCmd.py
@@ -541,6 +541,9 @@ def main():
 def internal_cd(args):
     """The internal CD command"""
     try:
+        if args[0].lower() == "/d":
+            # cmd.exe requires `/d` when changing volumes; we just ignore it
+            args.pop(0)
         if len(args) == 0:
             os.chdir(expand_env_vars('~'))
         else:

--- a/PyCmd.py
+++ b/PyCmd.py
@@ -547,7 +547,10 @@ def internal_cd(args):
         if len(args) == 0:
             os.chdir(expand_env_vars('~'))
         else:
-            target = args[0]
+            if len(args) == 1:
+                target = args[0]
+            else:
+                target = " ".join(args)
             if target != '\\' and target[1:] != ':\\':
                 target = target.rstrip('\\')
             target = expand_env_vars(target.strip('"').strip(' '))


### PR DESCRIPTION
These are mostly quality of life changes. Some things that cmd.exe's `cd` do are:
- allows specifying `/d` to change the volume along with the path, which PyCmd does already; as such, it is dropped.
- allows unquoted paths; this isn't a small change to fully support, as cmd.exe `cd` can tell that two arguments are separated by two spaces; the change only supports single-space-separated path substrings