### PR TITLE
Allow using characters typed via "Alt Gr" again (Follow up for Window.py)

### DIFF
--- a/PyCmd.py
+++ b/PyCmd.py
@@ -364,11 +364,10 @@ def main():
                     state.handle(ActionCode.ACTION_BACKSPACE_WORD)
                 elif rec.VirtualKeyCode == 191:
                     state.handle(ActionCode.ACTION_EXPAND)
-            elif is_ctrl_pressed(rec) and is_alt_pressed(rec):          # Ctrl-Alt-something
-                if rec.VirtualKeyCode == 75:            # Ctrl-Alt-K
-                    line = state.before_cursor + state.after_cursor
-                    state.handle(ActionCode.ACTION_ZAP)
-                    update_history('remove', line, pycmd_data_dir + '\\history', save_history_limit)
+            elif is_ctrl_pressed(rec) and is_alt_pressed(rec) and rec.VirtualKeyCode == 75: # Ctrl-Alt-K
+                line = state.before_cursor + state.after_cursor
+                state.handle(ActionCode.ACTION_ZAP)
+                update_history('remove', line, pycmd_data_dir + '\\history', save_history_limit)
             elif is_shift_pressed(rec) and rec.VirtualKeyCode == 33:    # Shift-PgUp
                 (_, t, _, b) = get_viewport()
                 scroll_buffer(t - b + 2)

--- a/Window.py
+++ b/Window.py
@@ -143,26 +143,26 @@ class Window(object):
             self.reset_cursor()
             self.display()
             rec = read_input()
-            if rec.Char == chr(0) or is_ctrl_pressed(rec) and not rec.VirtualKeyCode == 71 or is_alt_pressed(rec):
-                if rec.VirtualKeyCode == 37 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 66:
+            if rec.Char == chr(0) \
+               or (not is_ctrl_pressed(rec) and not is_alt_pressed(rec) and rec.VirtualKeyCode in [37, 39, 40, 38, 34, 33, 36, 35]) \
+               or (is_ctrl_pressed(rec) and not is_alt_pressed(rec) and rec.VirtualKeyCode in [66, 70, 78, 80, 86, 65, 69]) \
+               or (not is_ctrl_pressed(rec) and is_alt_pressed(rec) and rec.VirtualKeyCode == 86):
+                if rec.VirtualKeyCode == 37 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 66: # LEFT or CTRL+B
                     self.selected_column -= 1
-                elif rec.VirtualKeyCode == 39 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 70:
+                elif rec.VirtualKeyCode == 39 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 70: # RIGHT or CTRL+F
                     self.selected_column += 1
-                elif rec.VirtualKeyCode == 40 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 78:
+                elif rec.VirtualKeyCode == 40 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 78: # DOWN or CTRL+N
                     self.selected_line += 1
-                elif rec.VirtualKeyCode == 38 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 80:
+                elif rec.VirtualKeyCode == 38 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 80: # UP or CTRL+P
                     self.selected_line -= 1
-                elif rec.VirtualKeyCode == 34 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 86:
+                elif rec.VirtualKeyCode == 34 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 86: # PAGE DOWN or CTRL+V
                     self.selected_line += self.height
-                elif rec.VirtualKeyCode == 33 or is_alt_pressed(rec) and rec.VirtualKeyCode == 86:
+                elif rec.VirtualKeyCode == 33 or is_alt_pressed(rec) and rec.VirtualKeyCode == 86: # PAGE UP or ALT+V
                     self.selected_line -= self.height
-                elif rec.VirtualKeyCode == 36 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 65:
+                elif rec.VirtualKeyCode == 36 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 65: # HOME or CTRL+A
                     self.selected_column = 0
-                elif rec.VirtualKeyCode == 35 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 69:
+                elif rec.VirtualKeyCode == 35 or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 69: # END or CTRL+E
                     self.selected_column = self.num_columns
-                elif rec.VirtualKeyCode == 75 and is_ctrl_pressed(rec) and is_alt_pressed(rec) and can_zap:
-                    self.erase()
-                    return 'zap', self.entries[self.selected_line + self.selected_column * self.num_lines]
 
                 self.selected_line = Window._bound(self.selected_line, 0, self.num_lines - 1)
                 num_columns_current_row = self.num_columns
@@ -170,16 +170,19 @@ class Window(object):
                     num_columns_current_row -= 1
                 self.selected_column = Window._bound(self.selected_column, 0, num_columns_current_row - 1)
                 self._center_on_selection()
-            elif (rec.Char == chr(13) or rec.Char == '\t') and self.entries:
+            elif rec.VirtualKeyCode == 75 and is_ctrl_pressed(rec) and is_alt_pressed(rec) and can_zap: # CTRL+ALT+K
+                self.erase()
+                return 'zap', self.entries[self.selected_line + self.selected_column * self.num_lines]
+            elif (rec.Char == chr(13) or rec.Char == '\t') and self.entries: # ENTER or TAB
                 self.erase()
                 return 'select', self.entries[self.selected_line + self.selected_column * self.num_lines]
-            elif rec.Char == chr(27) or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 71:
+            elif rec.Char == chr(27) or is_ctrl_pressed(rec) and rec.VirtualKeyCode == 71: # ESC or CTRL+G
                 if self.filter:
                     self.filter = ''
                 else:
                     self.erase()
                     return None, None
-            elif not is_ctrl_pressed(rec):
+            else:
                 if rec.Char == '\b':
                     self.filter = self.filter[:-1]
                 else:            


### PR DESCRIPTION
Characters typed via "Alt Gr" also didn't appear in windows, e.g., for incremental search.
I'm not sure why the "not is_ctrl_pressed(rec)" was placed in the final condition, so I hope it doesn't brake anything else?