### PR TITLE
Fix two test failures (by Claude):

### DIFF
--- a/src/pycmd/Window.py
+++ b/src/pycmd/Window.py
@@ -47,7 +47,9 @@ class Window(object):
             # We print multiple columns to save space
             self.num_columns = (self.width - 1) // self.column_width
         else:
-            # We print a single column for clarity
+            self.num_columns = 1
+        if self.num_columns <= 1:
+            # Single column: use the full available width
             self.num_columns = 1
             self.column_width = self.width - 1
         self.num_lines = len(self.entries) // self.num_columns

--- a/src/pycmd/pycmd_public.py
+++ b/src/pycmd/pycmd_public.py
@@ -53,7 +53,7 @@ def abbrev_path(path = None):
                     # In this case, we use the entire name
                     elem_abbrev = elem
                     break
-        except PermissionError:
+        except (PermissionError, FileNotFoundError):
             # we were unable to list parent directory to check for collisions
             elem_abbrev = elem
         current_dir += os.sep + elem


### PR DESCRIPTION
1) abbrev_path() now also catches FileNotFoundError (in addition to
 PermissionError) when listing a parent directory fails; fixes test
 failure on Windows 11 where C:\Documents and Settings is a junction
 point that raises FileNotFoundError instead of PermissionError.

2) Window.filter setter now resets column_width to width-1 whenever
 the multi-column layout calculation ends up with only one column;
 previously that normalisation only happened in the else branch, so
 a zero-height viewport (no real console attached) would leave
 column_width at the raw max-entry-length value instead of the full
 available width.