### PR TITLE
Enable "Alt Gr" key again (CTRL + ALT) (2nd attempt)

### DIFF
--- a/src/pycmd/PyCmd.py
+++ b/src/pycmd/PyCmd.py
@@ -14,7 +14,7 @@ import copy
 from sys import stdout, stderr
 from pycmd.console import move_cursor, get_cursor, cursor_backward, set_cursor_attributes
 from pycmd.console import read_input, write_input
-from pycmd.console import is_ctrl_pressed, is_alt_pressed, is_shift_pressed, is_control_only
+from pycmd.console import is_ctrl_pressed, is_alt_pressed, is_left_alt_pressed, is_shift_pressed, is_control_only
 from pycmd.console import scroll_buffer, get_viewport, get_buffer_size, clear_screen
 from pycmd.console import remove_escape_sequences
 from pycmd.Window import Window
@@ -406,7 +406,7 @@ def main():
                     state.handle(ActionCode.ACTION_BACKSPACE_WORD)
                 elif rec.VirtualKeyCode == 191:         # Alt-/
                     state.handle(ActionCode.ACTION_EXPAND)
-            elif is_ctrl_pressed(rec) and is_alt_pressed(rec):  # Ctrl-Alt-Something 
+            elif is_ctrl_pressed(rec) and is_left_alt_pressed(rec) and ord(rec.Char) < 32:  # Ctrl-Alt-Something
                 if rec.VirtualKeyCode == 75:                # Ctrl-Alt-K
                     update_history('remove', state.line, pycmd_data_dir + ('/history' if state == state_command else '/chat_history'), save_history_limit)
                     state.handle(ActionCode.ACTION_ZAP)

--- a/src/pycmd/console/console_linux.py
+++ b/src/pycmd/console/console_linux.py
@@ -439,6 +439,10 @@ def is_alt_pressed(record):
     """Check whether the Alt key is pressed"""
     return record.ControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0
 
+def is_left_alt_pressed(record):
+    """Check whether the left Alt key is pressed (excludes AltGr, which sets right Alt)"""
+    return record.ControlKeyState & LEFT_ALT_PRESSED != 0
+
 def is_shift_pressed(record):
     """Check whether the Shift key is pressed"""
     return record.ControlKeyState & SHIFT_PRESSED != 0

--- a/src/pycmd/console/console_win32.py
+++ b/src/pycmd/console/console_win32.py
@@ -148,6 +148,10 @@ def is_alt_pressed(record):
     """Check whether the Alt key is pressed"""
     return record.ControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0
 
+def is_left_alt_pressed(record):
+    """Check whether the left Alt key is pressed (excludes AltGr, which sets right Alt)"""
+    return record.ControlKeyState & LEFT_ALT_PRESSED != 0
+
 def is_shift_pressed(record):
     """Check whether the Shift key is pressed"""
     return record.ControlKeyState & SHIFT_PRESSED != 0


### PR DESCRIPTION
1. rec.Char: AltGr+K produces a printable char (ord ≥ 32); true Ctrl+Alt+K produces a control char (ord < 32)
2. Left vs right Alt: AltGr sets RIGHT_ALT_PRESSED (not LEFT_ALT_PRESSED); true Alt+Ctrl uses LEFT_ALT_PRESSED

Using both conditions with AND ensures maximum precision: AltGr keys now fall through to the regular character handler instead of incorrectly triggering Ctrl-Alt-K or Ctrl-Alt-I.

Closes https://github.com/horeah/PyCmd/issues/33