### PR TITLE
Fix AttributeError when starting PyCmd with -k flag

### DIFF
--- a/src/pycmd/PyCmd.py
+++ b/src/pycmd/PyCmd.py
@@ -100,7 +100,6 @@ def main():
             # Run the specified command and continue
             if rest != []:
                 run_command(rest)
-                dir_hist.visit_cwd()
                 break
         elif switch in ['/C', '-C']:
             # Run the specified command end exit


### PR DESCRIPTION
- dir_hist.visit_cwd() was called inside the -k argument handler before dir_hist was initialised; init_dir_history() (called after the loop) already invokes visit_cwd(), so the early call was both wrong and redundant.
-  Closes #34